### PR TITLE
Whether, not Wether

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,3 @@
-
 # k
 
   keyboard event dispatcher.
@@ -52,19 +51,19 @@ k('shift + enter, ctrl + a', function(e){
 
 ### k.shift
 
-  Wether or not `shift` key is currently down.
+  Whether or not `shift` key is currently down.
 
 ### k.ctrl
 
-  Wether or not `ctrl` key is currently down.
+  Whether or not `ctrl` key is currently down.
 
 ### k.alt
 
-  Wether or not `alt` key is currently down.
+  Whether or not `alt` key is currently down.
 
 ### k.command
 
-  Wether or not `command` key is currently down.
+  Whether or not `command` key is currently down.
 
 ## dependencies
 


### PR DESCRIPTION
Also:

> According to Fowler's Modern English Usage (see note), "whether or not" is not strictly incorrect. The pertinent article acknowledges that "whether or not" can be a legitimate contraction of "whether it will or will not". Nevertheless, you should avoid the construction, as it is less often used than abused.

http://www.writersblock.ca/tips/monthtip/tipapr96.htm

Sorry, I had to.

Also, GitHub removed the leading `\n` in the beginning. I hope you don't mind.
