### PR TITLE
Use system modifier detector

### DIFF
--- a/proto.js
+++ b/proto.js
@@ -153,8 +153,8 @@ exports.bind = function(keys, fn){
  */
 
 exports.clear = function(){
-  for (var k in modifiers) {
-    this[modifiers[k]] = null;
+  for (var k in modifierCodes) {
+    this[modifierCodes[k]] = null;
   }
 };
 


### PR DESCRIPTION
The current implementation is not good enough, the user has to press a modifier key every time. Actually we want to use it this way:

press a ctrl key, hold on the ctrl key, and then hit other keys. We will not release ctrl key, but the keyup event by other keys will clear the modifier state.
