### PR TITLE
miss require event for destroy

### DIFF
--- a/proto.js
+++ b/proto.js
@@ -4,6 +4,7 @@
  */
 
 var keycode = require('keycode');
+var event = require('event');
 
 /**
  * modifiers.


### PR DESCRIPTION
A related issue:

https://github.com/yields/k/pull/2

Found that event is missing for `destroy` function.
