### PR TITLE
Do not call Array#slice if handler not found.

### DIFF
--- a/proto.js
+++ b/proto.js
@@ -119,7 +119,7 @@ exports.unbind = function(keys, fn){
       listeners[key] = [];
     } else {
       index = listeners[key].indexOf(fn);
-      listeners[key].splice(i, 1);
+      if (index > -1) listeners[key].splice(i, 1);
     }
   }
 


### PR DESCRIPTION
`k.unbind` is broken.

Array#slice will remove items from the end of the array if a negative index is given for the `index` argument.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/splice#Syntax

This behavior is giving your `unbind` test a false pass because you're just verifying the length of the handler array, not actual content. During the `unbind` call, the actual handler isn't found, so -1 is returned. You then call slice using -1 for the index, which removes the last handler in the array no matter what. You then check the length and see that the handler array is the correct length and assume success.

The handler array is actually an array of objects in this format:

`{ fn: Function, mods: Array }`

So calling `indexOf` and passing the handler function cannot succeed.
