### PR TITLE
Prevent shortcuts w/o modifiers from matching when modifiers pressed

### DIFF
--- a/proto.js
+++ b/proto.js
@@ -65,6 +65,9 @@ exports.handle = function(e, fn){
     mods = handle.mods;
     mlen = mods.length;
 
+    // Do not match if modifiers are pressed and handler has none defined:
+    if (this.modifiers === true && mlen == 0) break;
+
     for (var j = 0; j < mlen; ++j) {
       if (!this[mods[j]]) {
         invoke = null;


### PR DESCRIPTION
Here's an example of how the current functionality is broken:

``` js
k('r', function() {
  console.log('r');
});

k('shift + r', function() {
  console.log('shift + r');
});

// Press "r" – correct:
// -> "r"

// Press "shift + r" – broken:
// -> "shift + r"
// -> "r"
```

The current implementation is broken because `invoke` defaults to `true`, and since `mlen` is `0`, there is never an opportunity to set `invoke` back to `null` because we never enter the loop which performs that operation:

https://github.com/yields/k/blob/master/proto.js#L68

This patch simply breaks out of the loop if modifiers are pressed but the current handler in the loop has none defined.
