### PR TITLE
Fix an issue with older browsers and the reserved 'super' keyword.

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,4 +1,9 @@
 
+0.6.2 / 2014-05-19
+==================
+
+ * fix for older browsers and reserved keywords (<IE9)
+
 0.6.1 / 2014-03-03
 ==================
 

--- a/component.json
+++ b/component.json
@@ -2,7 +2,7 @@
   "name": "k",
   "repo": "yields/k",
   "description": "keyboard event dispatcher.",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "keywords": ["keyboard"],
   "license": "MIT",
   "scripts": ["lib/index.js", "lib/proto.js"],

--- a/lib/proto.js
+++ b/lib/proto.js
@@ -23,9 +23,10 @@ var modifiers = {
 
 /**
  * Super key.
+ * (must use subscript vs. dot notation to avoid issues with older browsers)
  */
 
-exports.super = 'mac' == os
+exports[ 'super' ] = 'mac' == os
   ? 'command'
   : 'ctrl';
 
@@ -49,7 +50,7 @@ exports.handle = function(e, fn){
   // modifiers
   var mod = modifiers[code];
   if ('keydown' == event && mod) {
-    this.super = exports.super == mod;
+    this[ 'super' ] = exports[ 'super' ] == mod;
     this[mod] = true;
     this.modifiers = true;
     return;
@@ -247,7 +248,7 @@ exports.ignore = function(e){
  */
 
 function parseKeys(keys){
-  keys = keys.replace('super', exports.super);
+  keys = keys.replace('super', exports[ 'super' ]);
 
   var all = ',' != keys
     ? keys.split(/ *, */)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "k-component",
   "description": "keyboard event dispatcher",
   "author": "Amir Abu Shareb <yields@icloud.com>",
-  "version": "0.4.0",
+  "version": "0.6.2",
   "main": "index.js",
   "dependencies": {
     "keycode-component": "*",


### PR DESCRIPTION
IE8 (and below, I believe) will throw errors when using dot notation and reserved words. 'super' is a reserved word. Using subscript notation fixes the issue.
