### PR TITLE
Modifier state invalid after window loses and regains focus

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -24,10 +24,11 @@ module.exports = function(el){
   function k(e, fn){ k.handle(e, fn) };
   k._handle = bind(k, proto.handle);
   k._clear = bind(k, proto.clear);
+  k._reset = bind(k, proto.reset);
   event.bind(el, 'keydown', k._handle, false);
   event.bind(el, 'keyup', k._handle, false);
   event.bind(el, 'keyup', k._clear, false);
-  event.bind(el, 'focus', k._clear, false);
+  event.bind(el, 'focus', k._reset, false);
   for (var p in proto) k[p] = proto[p];
   k.listeners = [];
   k.active = 0;

--- a/lib/proto.js
+++ b/lib/proto.js
@@ -227,6 +227,21 @@ exports.clear = function(e){
 };
 
 /**
+ * Clear all modifiers on `focus`.
+ *
+ * @api private
+ */
+
+exports.reset = function(e){
+  this.active = 0;
+  this.modifiers =
+  this.command =
+  this.shift =
+  this.ctrl =
+  this.alt = null;
+};
+
+/**
  * Ignore all input elements by default.
  *
  * @param {Event} e

--- a/test/test.js
+++ b/test/test.js
@@ -265,6 +265,22 @@ describe('k', function(){
       assert(1 == invoked);
     })
 
+    it('`a b c` and `c`', function(){
+      var el = elem();
+      var k = dispatcher(el);
+      var invoked = 0;
+      k('a b c', function(){ ++invoked; });
+      k('c', function(){ ++invoked; });
+      press(el, 'a')();
+      assert(0 == invoked);
+      press(el, 'b')();
+      assert(0 == invoked);
+      press(el, 'c')();
+      assert(1 == invoked);
+      press(el, 'c')();
+      assert(2 == invoked);
+    })
+
     it('`command + a b c`', function(){
       var el = elem();
       var k = dispatcher(el);

--- a/test/test.js
+++ b/test/test.js
@@ -400,7 +400,21 @@ describe('k', function(){
       ctrl();
       assert(null == k.modifiers);
     })
+
+    it('should be `falsey` after regaining focus', function() {
+      var el = elem();
+      var k = dispatcher(el);
+      assert(null == k.modifiers);
+      assert(null == k.ctrl);
+      press(el, 'ctrl');
+      assert(true == k.modifiers);
+      assert(true == k.ctrl);
+      el.dispatchEvent(new FocusEvent('focus'));
+      assert(null == k.modifiers);
+      assert(null == k.ctrl);
+    })
   })
+
 
   // press `el` with `code`
 


### PR DESCRIPTION
Whenever window loses focus as a result of a keyboard related action the modifier state might be left in an inconsistent state - for example when user presses `Alt+Tab` window receives `keydown` on `Alt` but no related `keyup` event (since another window is active by then).

That's why `k` tries to clean up modifier state on `focus` event, but for some time now it was not working since clear handler assumed it was called on a keyboard related event.

New `reset` handler cleans up modifier state unconditionally.
